### PR TITLE
update brawllib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "brawllib_rs"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d717c9edd5c2e0d94873607ff5474a069fe7f884e0aa969f2ed01f68ef5aebd1"
+checksum = "2dcc5f8777f3a5bbffbbcf52a2396ae391fb185a6102c1ae7644a9faf96ddbe6"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",


### PR DESCRIPTION
Includes an important fix to compressed files allowing most recent release of P+ to parse properly.