### PR TITLE
Compress web data

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-            # `toolchain: stable` results in the latest stable toolchain being installed.
-            # However as soon as we use cargo the real version specified in rust-toolchain.toml replaces the stable toolchain.
-            #
-            # When something like https://github.com/actions-rs/toolchain/pull/184 lands we can delete this line and get a nice speedup
-            profile: minimal
-            toolchain: stable
       - name: Build & test
         run: |
           cargo test --release

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,14 +41,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        # `toolchain: stable` results in the latest stable toolchain being installed.
-        # However as soon as we use cargo the real version specified in rust-toolchain.toml replaces the stable toolchain.
-        #
-        # When something like https://github.com/actions-rs/toolchain/pull/184 lands we can delete this line and get a nice speedup
-        profile: minimal
-        toolchain: stable
     - uses: Swatinem/rust-cache@v1
       with:
         # rust-cache already handles all the sane defaults for caching rust builds.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d09dbe0e490df5da9d69b36dca48a76635288a82f92eca90024883a56202026d"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c8503f93e6d144ee5690907ba22db7ba79ab001a932ab99034f0fe836b3df"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,7 +1079,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
+ "indexmap 2.1.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.0.0",
  "indexmap 2.1.0",
  "slab",
  "tokio",
@@ -1111,15 +1185,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ce4ef31cda248bbdb6e6820603b82dfcd9e833db65a43e997a0ccec777d11fe"
 
 [[package]]
 name = "httparse"
@@ -1149,9 +1263,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.22",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1164,17 +1278,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.0",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "rustls 0.21.10",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdea9aac0dbe5a9240d68cfd9501e2db94222c6dc06843e06640b9e07f0fdc67"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.1.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1383,6 +1534,12 @@ checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -1750,6 +1907,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.43",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,10 +2157,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.22",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -2054,9 +2231,11 @@ dependencies = [
 name = "rukaidata_website"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "bincode",
  "brawllib_rs",
  "env_logger",
+ "flate2",
  "futures",
  "getopts",
  "handlebars",
@@ -2068,6 +2247,8 @@ dependencies = [
  "serde_json",
  "sha2",
  "subprocess",
+ "tokio",
+ "tower-http",
  "wasm-bindgen-cli-support",
 ]
 
@@ -2138,6 +2319,12 @@ dependencies = [
  "ring 0.17.7",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -2237,6 +2424,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,6 +2493,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2442,6 +2648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,7 +2796,9 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -2654,6 +2868,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.0"
+source = "git+https://github.com/rukai/tower-http?branch=servedir_compress_in_place_hack#c91de8f6f20840869ebf206b5ecdc2184e062502"
+dependencies = [
+ "bitflags 2.4.1",
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2712,7 +2972,7 @@ dependencies = [
  "base64 0.13.1",
  "byteorder",
  "bytes",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "rand",

--- a/deploy_s3/deploy.sh
+++ b/deploy_s3/deploy.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e -u
+cd "$( dirname -- "${BASH_SOURCE[0]}" )/../root"
+
+# `cache-control: max-age=31536000` results in the browser never requesting the file until the cache is cleaned or cleared.
+echo -e "\ndeploy assets_static"
+aws s3 sync --exclude "*" --include "*.png" assets_static s3://$OUTPUT_BUCKET_NAME/assets_static --cache-control max-age=31536000 --content-encoding gzip
+
+# `cache-control: no-cache` results in:
+# 1.   a 5 minute period in which no requests are made to the server, relying entirely on cached data (browser dependent)
+# 2.   requests are then made to the server to verify if the cache is up to date (HTTP 304) or not up to date (HTTP 200)
+echo -e "\ndeploy everything else"
+aws s3 sync . s3://$OUTPUT_BUCKET_NAME --exclude "assets_static/*" --cache-control no-cache --content-encoding gzip

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 # Rukaidata
+
 [![dependency status](https://deps.rs/repo/github/rukai/rukaidata/status.svg)](https://deps.rs/repo/github/rukai/rukaidata)
 
 Uses [brawllib_rs](https://github.com/rukai/brawllib_rs) to display frame data on characters.
@@ -7,23 +8,20 @@ How does it work? Read the [writeup](docs/writeup.md).
 
 ## Run the rukaidata website on your machine
 
-1.  Install stable rust via https://rustup.rs/ (use the default settings)
-2.  Right click brawl in dolphin game list -> Properties -> Filesystem -> Disc -> Right click Partition 1 -> Extract Files... -> select the directory `data/Brawl`
-3.  Copy the entire contents of a brawl mod sd card to the directory `data/MODNAMEHERE` **(optional)**
-4.  Open a terminal and `cd` to the directory this readme is in.
-5.  Run the command: `cd website`
-6.  Run the command: `cargo run --release -- -w` This generates the website into the `root` directory.
-7.  Run a webserver on the `root` directory to access the generated website e.g.
-    1.  Install python. Make sure to add python to your PATH environment variable, there should be a checkbox for this in the windows installer other OSs should handle this by default.
-    2.  Run `serve.sh` for linux/mac or `serve.bat` for windows.
-    3.  Navigate to http://localhost:8000 in your webbrowser.
+1. Install stable rust via <https://rustup.rs/> (use the default settings)
+2. Right click brawl in dolphin game list -> Properties -> Filesystem -> Disc -> Right click Partition 1 -> Extract Files... -> select the directory `data/Brawl`
+3. Copy the entire contents of a brawl mod sd card to the directory `data/MODNAMEHERE` **(optional)**
+4. Open a terminal and `cd` to the directory this readme is in.
+5. Run the command: `cd website`
+6. Run the command: `cargo run --release -- -w` This generates the website into the `root` directory.
+7. Run the command: `cargo run --release -- -s` This serves the website at <http://localhost:8000>
 
 ## Filters
 
 You can use the following arguments to specify filters:
 
-*   `-m` List of mod folders in `data/` to use
-*   `-f` List of fighters to use, specified by their internal name
+* `-m` List of mod folders in `data/` to use
+* `-f` List of fighters to use, specified by their internal name
 
 e.g. To only generate framedata for PM3.6 marth and squirtle run this command:
 
@@ -35,19 +33,40 @@ Using filters will save you generation time and disk space.
 
 By default rukaidata will generate no output, however you use the following flags to additively specify what to generate:
 
-*   `-w` Generate webpages
-*   `-g` Generate subaction gifs`
+* `-w` Generate webpages
+* `-g` Generate subaction gifs`
 
 e.g. To generate webpages and gifs for everything run this command:
 
 `cargo run --release -- -wg`
 
+## Serving
+
+rukaidata is designed to be served by AWS S3.
+Additionally I also use:
+
+* AWS Cloudfront in front of S3 for CDN.
+* Route 53 for domain name registration
+* ACM for HTTPS
+
+However to test locally you can use the `-s` flag to run a webserver.
+You could also use this functionality to serve in production but I've never tried it.
+You would need to put something like nginx in front to get HTTPS
+
+### Generate the site and then serve it
+
+`cargo run --release -- -wgs`
+
+### serve a previously generated site
+
+`cargo run --release -- -s`
 
 ## `data` folder cleanup
 
 Most of the files in the `data` folder are actually unused by rukaidata, so after you get everything working, feel free to delete unused files, maintaining the same directory tree structure.
 The following files and folders must be kept:
-*   `*.pac` files in the `fighter` folder
-*   `RSBE01.gct`
+
+* `*.pac` files in the `fighter` folder
+* `RSBE01.gct`
 
 However I may make other files required in the future so watch out. :)

--- a/serve.bat
+++ b/serve.bat
@@ -1,2 +1,0 @@
-cd root
-python -m http.server

--- a/serve.sh
+++ b/serve.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-cd root
-python3 -m http.server

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -23,3 +23,7 @@ futures = "0.3"
 subprocess = "0.2.7"
 bincode = "1"
 wasm-bindgen-cli-support = "0.2.78"
+flate2 = "1.0.28"
+tokio = { version = "1.35.1", features = ["full"] }
+axum = "0.7.3"
+tower-http = { version = "0.5.0", features = ["fs"], git = "https://github.com/rukai/tower-http", branch = "servedir_compress_in_place_hack" }

--- a/website/src/assets/mod.rs
+++ b/website/src/assets/mod.rs
@@ -1,4 +1,4 @@
-use crate::cli::CLIResults;
+use crate::{cli::CLIResults, output::OutDir};
 use std::fmt::Write;
 use std::fs;
 use std::path::Path;
@@ -36,7 +36,7 @@ fn hash(value: &[u8]) -> String {
 
 impl AssetPaths {
     pub fn new(cli: &CLIResults) -> AssetPaths {
-        fs::create_dir_all("../root/assets_static").unwrap();
+        let dir = OutDir::new("assets_static");
 
         let style_css = {
             let contents = include_str!("style.css");
@@ -44,27 +44,19 @@ impl AssetPaths {
             let minified = minifier::css::minify(contents).unwrap();
 
             let hash = hash(minified.as_bytes());
-            let path = format!("/assets_static/{hash}.css");
-            fs::write(format!("../root/{path}"), minified).unwrap();
-            path
+            dir.create_compressed_file(&format!("{hash}.css"), minified.as_bytes())
         };
 
         let spritesheet_png = {
             let contents = include_bytes!("spritesheet.png");
-
             let hash = hash(contents);
-            let path = format!("/assets_static/{hash}.png");
-            fs::write(format!("../root/{path}"), contents).unwrap();
-            path
+            dir.create_compressed_file(&format!("{hash}.png"), contents)
         };
 
         let favicon_png = {
             let contents = include_bytes!("favicon.png");
-
             let hash = hash(contents);
-            let path = format!("/assets_static/{hash}.png");
-            fs::write(format!("../root/{path}"), contents).unwrap();
-            path
+            dir.create_compressed_file(&format!("{hash}.png"), contents)
         };
 
         let subaction_render_js = {
@@ -75,9 +67,7 @@ impl AssetPaths {
             // Can't complain though, the minifier repo does say its not ready yet :P
 
             let hash = hash(minified.as_bytes());
-            let path = format!("/assets_static/{hash}.js");
-            fs::write(format!("../root/{path}"), minified.as_bytes()).unwrap();
-            path
+            dir.create_compressed_file(&format!("{hash}.js"), minified.as_bytes())
         };
 
         const WASM_FILE_NAME: &str = "fighter_renderer_bg.wasm";
@@ -119,9 +109,7 @@ impl AssetPaths {
                 ))
                 .unwrap();
                 let hash = hash(&contents);
-                let path = format!("/assets_static/{hash}.wasm");
-                fs::write(format!("../root/{path}"), contents).unwrap();
-                path
+                dir.create_compressed_file(&format!("{hash}.wasm"), &contents)
             }
         } else {
             String::new()
@@ -140,9 +128,7 @@ impl AssetPaths {
             contents = contents.replace(WASM_FILE_NAME, wasm_file_name);
 
             let hash = hash(contents.as_bytes());
-            let path = format!("/assets_static/{hash}.js");
-            fs::write(format!("../root/{path}"), contents).unwrap();
-            path
+            dir.create_compressed_file(&format!("{hash}.js"), contents.as_bytes())
         } else {
             String::new()
         };

--- a/website/src/cli.rs
+++ b/website/src/cli.rs
@@ -15,6 +15,7 @@ pub(crate) fn parse_cli() -> Option<CLIResults> {
     opts.optflag("g", "gif", "Enable subaction gif generation");
     opts.optflag("w", "web", "Enable website generation");
     opts.optflag("a", "wasm", "Use wasm/wgpu backend");
+    opts.optflag("s", "serve", "serve the website after generating it");
     opts.optopt(
         "m",
         "mods",
@@ -53,6 +54,7 @@ pub(crate) fn parse_cli() -> Option<CLIResults> {
     let generate_gifs = matches.opt_present("g");
     let generate_web = matches.opt_present("w");
     let wasm_mode = matches.opt_present("a");
+    let serve = matches.opt_present("s");
 
     Some(CLIResults {
         mod_names,
@@ -60,6 +62,7 @@ pub(crate) fn parse_cli() -> Option<CLIResults> {
         generate_gifs,
         generate_web,
         wasm_mode,
+        serve,
     })
 }
 
@@ -69,4 +72,5 @@ pub struct CLIResults {
     pub generate_gifs: bool,
     pub generate_web: bool,
     pub wasm_mode: bool,
+    pub serve: bool,
 }

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -14,8 +14,10 @@ pub mod brawl_data;
 pub mod cli;
 pub mod gif;
 pub mod logger;
+pub mod output;
 pub mod page;
 pub mod process_scripts;
+mod serve;
 
 use assets::AssetPaths;
 use brawl_data::BrawlMods;
@@ -50,6 +52,10 @@ fn main() {
 
             if cli.generate_gifs {
                 gif::generate(&brawl_mods);
+            }
+
+            if cli.serve {
+                serve::serve();
             }
         }
     }

--- a/website/src/output.rs
+++ b/website/src/output.rs
@@ -1,0 +1,46 @@
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use std::fs;
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone)]
+pub struct OutDir {
+    path: PathBuf,
+}
+
+impl OutDir {
+    pub fn new(path: &str) -> Self {
+        let path = Path::new("../root").join(path);
+        fs::create_dir_all(&path).unwrap();
+        OutDir { path }
+    }
+
+    pub fn compressed_file_writer(&self, file_name: &str) -> GzEncoder<File> {
+        let file = File::create(self.path.join(file_name)).unwrap();
+        flate2::write::GzEncoder::new(file, Compression::best())
+    }
+
+    pub fn create_compressed_file(&self, file_name: &str, data: &[u8]) -> String {
+        let path = self.path.join(file_name);
+        let file = File::create(&path).unwrap();
+        let mut writer = flate2::write::GzEncoder::new(file, Compression::best()); //TODO: try deflate
+        writer.write_all(data).unwrap();
+        Path::new("/")
+            .join(path.strip_prefix("../root").unwrap())
+            .into_os_string()
+            .into_string()
+            .unwrap()
+    }
+
+    pub fn create_file(&self, file_name: &str, data: &[u8]) -> String {
+        let path = self.path.join(file_name);
+        std::fs::write(&path, data).unwrap();
+        Path::new("/")
+            .join(path.strip_prefix("../root").unwrap())
+            .into_os_string()
+            .into_string()
+            .unwrap()
+    }
+}

--- a/website/src/page/action.rs
+++ b/website/src/page/action.rs
@@ -1,13 +1,10 @@
-use std::fs;
-use std::fs::File;
-
-use handlebars::Handlebars;
-use rayon::prelude::*;
-
 use crate::assets::AssetPaths;
 use crate::brawl_data::BrawlMods;
+use crate::output::OutDir;
 use crate::page::NavLink;
 use crate::process_scripts;
+use handlebars::Handlebars;
+use rayon::prelude::*;
 
 pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetPaths) {
     for brawl_mod in &brawl_mods.mods {
@@ -23,11 +20,10 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
                     current: other_name == &fighter.fighter.name,
                 });
             }
-            fs::create_dir_all(format!(
-                "../root/{}/{}/actions/",
+            let dir = OutDir::new(&format!(
+                "{}/{}/actions/",
                 brawl_mod.name, fighter.fighter.name
-            ))
-            .unwrap();
+            ));
             fighter
                 .fighter
                 .actions
@@ -67,11 +63,7 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
                         fighter_links: &fighter_links,
                     };
 
-                    let path = format!(
-                        "../root/{}/{}/actions/{}.html",
-                        brawl_mod.name, fighter.fighter.name, action.name
-                    );
-                    let file = File::create(path).unwrap();
+                    let file = dir.compressed_file_writer(&format!("{}.html", action.name));
                     handlebars.render_to_write("action", &page, file).unwrap();
                     info!(
                         "{} {} action {}",

--- a/website/src/page/actions.rs
+++ b/website/src/page/actions.rs
@@ -1,12 +1,9 @@
-use std::fs;
-use std::fs::File;
-
-use handlebars::Handlebars;
-use rayon::prelude::*;
-
 use crate::assets::AssetPaths;
 use crate::brawl_data::BrawlMods;
+use crate::output::OutDir;
 use crate::page::NavLink;
+use handlebars::Handlebars;
+use rayon::prelude::*;
 
 pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetPaths) {
     for brawl_mod in &brawl_mods.mods {
@@ -32,16 +29,8 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
                 assets,
             };
 
-            fs::create_dir_all(format!(
-                "../root/{}/{}/actions",
-                brawl_mod.name, fighter.name
-            ))
-            .unwrap();
-            let path = format!(
-                "../root/{}/{}/actions/index.html",
-                brawl_mod.name, fighter.name
-            );
-            let file = File::create(path).unwrap();
+            let file = OutDir::new(&format!("{}/{}/actions", brawl_mod.name, fighter.name))
+                .compressed_file_writer("index.html");
             handlebars.render_to_write("actions", &page, file).unwrap();
         });
     }

--- a/website/src/page/attributes.rs
+++ b/website/src/page/attributes.rs
@@ -1,14 +1,10 @@
-use std::fs;
-use std::fs::File;
-
-use handlebars::Handlebars;
-use rayon::prelude::*;
-
-use brawllib_rs::sakurai::fighter_data::FighterAttributes;
-
 use crate::assets::AssetPaths;
 use crate::brawl_data::BrawlMods;
+use crate::output::OutDir;
 use crate::page::NavLink;
+use brawllib_rs::sakurai::fighter_data::FighterAttributes;
+use handlebars::Handlebars;
+use rayon::prelude::*;
 
 pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetPaths) {
     for brawl_mod in &brawl_mods.mods {
@@ -23,12 +19,8 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
                 attributes: attributes_to_strings(&fighter.attributes),
             };
 
-            fs::create_dir_all(format!("../root/{}/{}", brawl_mod.name, fighter.name)).unwrap();
-            let path = format!(
-                "../root/{}/{}/attributes.html",
-                brawl_mod.name, fighter.name
-            );
-            let file = File::create(path).unwrap();
+            let file = OutDir::new(&format!("{}/{}", brawl_mod.name, fighter.name))
+                .compressed_file_writer("attributes.html");
             handlebars
                 .render_to_write("attributes", &page, file)
                 .unwrap();

--- a/website/src/page/brawl_mod.rs
+++ b/website/src/page/brawl_mod.rs
@@ -1,11 +1,8 @@
-use std::fs;
-use std::fs::File;
-
-use handlebars::Handlebars;
-
 use crate::assets::AssetPaths;
 use crate::brawl_data::BrawlMods;
+use crate::output::OutDir;
 use crate::page::NavLink;
+use handlebars::Handlebars;
 
 pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetPaths) {
     for brawl_mod in &brawl_mods.mods {
@@ -25,9 +22,7 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
             assets,
         };
 
-        fs::create_dir_all(format!("../root/{}", brawl_mod.name)).unwrap();
-        let path = format!("../root/{}/index.html", brawl_mod.name);
-        let file = File::create(path).unwrap();
+        let file = OutDir::new(&brawl_mod.name).compressed_file_writer("index.html");
         handlebars.render_to_write("mod", &page, file).unwrap();
     }
 }

--- a/website/src/page/error.rs
+++ b/website/src/page/error.rs
@@ -1,17 +1,15 @@
-use std::fs::File;
-
-use handlebars::Handlebars;
-
 use crate::assets::AssetPaths;
 use crate::brawl_data::BrawlMods;
+use crate::output::OutDir;
 use crate::page::NavLink;
+use handlebars::Handlebars;
 
 pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetPaths) {
     let page = ErrorPage {
         assets,
         mod_links: brawl_mods.gen_mod_links(String::new()),
     };
-    let file = File::create("../root/error.html").unwrap();
+    let file = OutDir::new(".").compressed_file_writer("error.html");
     handlebars.render_to_write("error", &page, file).unwrap();
 }
 

--- a/website/src/page/fighter.rs
+++ b/website/src/page/fighter.rs
@@ -1,12 +1,9 @@
-use std::fs;
-use std::fs::File;
-
-use handlebars::Handlebars;
-use rayon::prelude::*;
-
 use crate::assets::AssetPaths;
 use crate::brawl_data::BrawlMods;
+use crate::output::OutDir;
 use crate::page::NavLink;
+use handlebars::Handlebars;
+use rayon::prelude::*;
 
 pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetPaths) {
     for brawl_mod in &brawl_mods.mods {
@@ -20,9 +17,8 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
                 assets,
             };
 
-            fs::create_dir_all(format!("../root/{}/{}", brawl_mod.name, fighter.name)).unwrap();
-            let path = format!("../root/{}/{}/index.html", brawl_mod.name, fighter.name);
-            let file = File::create(path).unwrap();
+            let file = OutDir::new(&format!("{}/{}", brawl_mod.name, fighter.name))
+                .compressed_file_writer("index.html");
             handlebars.render_to_write("fighter", &page, file).unwrap();
         });
     }

--- a/website/src/page/index.rs
+++ b/website/src/page/index.rs
@@ -1,10 +1,8 @@
-use std::fs::File;
-
-use handlebars::Handlebars;
-
 use crate::assets::AssetPaths;
 use crate::brawl_data::BrawlMods;
+use crate::output::OutDir;
 use crate::page::NavLink;
+use handlebars::Handlebars;
 
 pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetPaths) {
     let page = IndexPage {
@@ -12,8 +10,8 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
         mod_links: brawl_mods.gen_mod_links(String::new()),
         assets,
     };
-    let file = File::create("../root/index.html").unwrap();
-    handlebars.render_to_write("index", &page, file).unwrap();
+    let writer = OutDir::new(".").compressed_file_writer("index.html");
+    handlebars.render_to_write("index", &page, writer).unwrap();
 }
 
 #[derive(Serialize)]

--- a/website/src/page/script.rs
+++ b/website/src/page/script.rs
@@ -1,13 +1,10 @@
-use std::fs;
-use std::fs::File;
-
-use handlebars::Handlebars;
-use rayon::prelude::*;
-
 use crate::assets::AssetPaths;
 use crate::brawl_data::BrawlMods;
+use crate::output::OutDir;
 use crate::page::NavLink;
 use crate::process_scripts;
+use handlebars::Handlebars;
+use rayon::prelude::*;
 
 pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetPaths) {
     for brawl_mod in &brawl_mods.mods {
@@ -51,16 +48,11 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
                         assets,
                     };
 
-                    fs::create_dir_all(format!(
-                        "../root/{}/{}/scripts",
+                    let dir = OutDir::new(&format!(
+                        "{}/{}/scripts",
                         brawl_mod.name, fighter.fighter.name
-                    ))
-                    .unwrap();
-                    let path = format!(
-                        "../root/{}/{}/scripts/0x{:x}.html",
-                        brawl_mod.name, fighter.fighter.name, script.offset
-                    );
-                    let file = File::create(path).unwrap();
+                    ));
+                    let file = dir.compressed_file_writer(&format!("0x{:x}.html", script.offset));
                     handlebars.render_to_write("script", &page, file).unwrap();
                     info!(
                         "{} {} 0x{:x}",
@@ -95,16 +87,11 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
                         assets,
                     };
 
-                    fs::create_dir_all(format!(
-                        "../root/{}/{}/scripts_common",
+                    let dir = OutDir::new(&format!(
+                        "{}/{}/scripts_common",
                         brawl_mod.name, fighter.fighter.name
-                    ))
-                    .unwrap();
-                    let path = format!(
-                        "../root/{}/{}/scripts_common/0x{:x}.html",
-                        brawl_mod.name, fighter.fighter.name, script.offset
-                    );
-                    let file = File::create(path).unwrap();
+                    ));
+                    let file = dir.compressed_file_writer(&format!("0x{:x}.html", script.offset));
                     handlebars.render_to_write("script", &page, file).unwrap();
                     info!(
                         "{} {} 0x{:x}",
@@ -139,16 +126,11 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
                         assets,
                     };
 
-                    fs::create_dir_all(format!(
-                        "../root/{}/{}/scripts_common",
+                    let dir = OutDir::new(&format!(
+                        "{}/{}/scripts_common",
                         brawl_mod.name, fighter.fighter.name
-                    ))
-                    .unwrap();
-                    let path = format!(
-                        "../root/{}/{}/scripts_common/{}.html",
-                        brawl_mod.name, fighter.fighter.name, script.name
-                    );
-                    let file = File::create(path).unwrap();
+                    ));
+                    let file = dir.compressed_file_writer(&format!("{}.html", script.name));
                     handlebars.render_to_write("script", &page, file).unwrap();
                     info!(
                         "{} {} {}",

--- a/website/src/page/scripts.rs
+++ b/website/src/page/scripts.rs
@@ -1,12 +1,9 @@
-use std::fs;
-use std::fs::File;
-
-use handlebars::Handlebars;
-use rayon::prelude::*;
-
 use crate::assets::AssetPaths;
 use crate::brawl_data::BrawlMods;
+use crate::output::OutDir;
 use crate::page::NavLink;
+use handlebars::Handlebars;
+use rayon::prelude::*;
 
 pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetPaths) {
     for brawl_mod in &brawl_mods.mods {
@@ -25,16 +22,8 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
                 assets,
             };
 
-            fs::create_dir_all(format!(
-                "../root/{}/{}/scripts",
-                brawl_mod.name, fighter.name
-            ))
-            .unwrap();
-            let path = format!(
-                "../root/{}/{}/scripts/index.html",
-                brawl_mod.name, fighter.name
-            );
-            let file = File::create(path).unwrap();
+            let file = OutDir::new(&format!("{}/{}/scripts", brawl_mod.name, fighter.name))
+                .compressed_file_writer("index.html");
             handlebars.render_to_write("scripts", &page, file).unwrap();
         });
     }

--- a/website/src/page/subactions.rs
+++ b/website/src/page/subactions.rs
@@ -1,12 +1,9 @@
-use std::fs;
-use std::fs::File;
-
-use handlebars::Handlebars;
-use rayon::prelude::*;
-
 use crate::assets::AssetPaths;
 use crate::brawl_data::{BrawlMods, SubactionLinks};
+use crate::output::OutDir;
 use crate::page::NavLink;
+use handlebars::Handlebars;
+use rayon::prelude::*;
 
 pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetPaths) {
     for brawl_mod in &brawl_mods.mods {
@@ -21,16 +18,8 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
                 assets,
             };
 
-            fs::create_dir_all(format!(
-                "../root/{}/{}/subactions",
-                brawl_mod.name, fighter.name
-            ))
-            .unwrap();
-            let path = format!(
-                "../root/{}/{}/subactions/index.html",
-                brawl_mod.name, fighter.name
-            );
-            let file = File::create(path).unwrap();
+            let file = OutDir::new(&format!("{}/{}/subactions", brawl_mod.name, fighter.name))
+                .compressed_file_writer("index.html");
             handlebars
                 .render_to_write("subactions", &page, file)
                 .unwrap();

--- a/website/src/page/variables.rs
+++ b/website/src/page/variables.rs
@@ -1,12 +1,9 @@
-use std::fs;
-use std::fs::File;
-
-use handlebars::Handlebars;
-use rayon::prelude::*;
-
 use crate::assets::AssetPaths;
 use crate::brawl_data::BrawlMods;
+use crate::output::OutDir;
 use crate::page::NavLink;
+use handlebars::Handlebars;
+use rayon::prelude::*;
 
 pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetPaths) {
     for brawl_mod in &brawl_mods.mods {
@@ -20,9 +17,8 @@ pub fn generate(handlebars: &Handlebars, brawl_mods: &BrawlMods, assets: &AssetP
                 assets,
             };
 
-            fs::create_dir_all(format!("../root/{}/{}", brawl_mod.name, fighter.name)).unwrap();
-            let path = format!("../root/{}/{}/variables.html", brawl_mod.name, fighter.name);
-            let file = File::create(path).unwrap();
+            let file = OutDir::new(&format!("{}/{}", brawl_mod.name, fighter.name))
+                .compressed_file_writer("variables.html");
             handlebars
                 .render_to_write("variables", &page, file)
                 .unwrap();

--- a/website/src/serve.rs
+++ b/website/src/serve.rs
@@ -1,0 +1,19 @@
+use axum::Router;
+use tower_http::services::ServeDir;
+
+pub fn serve() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(run())
+}
+
+async fn run() {
+    // build our application with a route
+    let app = Router::new().nest_service("/", ServeDir::new("../root").precompressed_gzip());
+
+    // run it
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:8000")
+        .await
+        .unwrap();
+    println!("listening on {}", listener.local_addr().unwrap());
+    axum::serve(listener, app).await.unwrap();
+}


### PR DESCRIPTION
All output files are now compressed with gzip.
This drastically reduces both storage and network usage.

I have included the S3 deployment script with this PR to make it clear how to deploy to S3 with this new setup.
I've also replaced the old `python -m http.server` with an axum server as the python webserver does not support gzip at all.