### PR TITLE
Make wasm default

### DIFF
--- a/website/src/assets/mod.rs
+++ b/website/src/assets/mod.rs
@@ -71,7 +71,9 @@ impl AssetPaths {
         };
 
         const WASM_FILE_NAME: &str = "fighter_renderer_bg.wasm";
-        let fighter_renderer_wasm = if args.wasm_mode {
+        let fighter_renderer_wasm = if args.legacy_renderer {
+            String::new()
+        } else {
             {
                 let all_args = if env!("PROFILE") == "release" {
                     vec!["build", "--release"]
@@ -111,11 +113,11 @@ impl AssetPaths {
                 let hash = hash(&contents);
                 dir.create_compressed_file(&format!("{hash}.wasm"), &contents)
             }
-        } else {
-            String::new()
         };
 
-        let fighter_renderer_js = if args.wasm_mode {
+        let fighter_renderer_js = if args.legacy_renderer {
+            String::new()
+        } else {
             let mut contents =
                 fs::read_to_string("../fighter_renderer/target/generated/fighter_renderer.js")
                     .unwrap();
@@ -129,8 +131,6 @@ impl AssetPaths {
 
             let hash = hash(contents.as_bytes());
             dir.create_compressed_file(&format!("{hash}.js"), contents.as_bytes())
-        } else {
-            String::new()
         };
 
         AssetPaths {

--- a/website/src/cli.rs
+++ b/website/src/cli.rs
@@ -18,9 +18,9 @@ pub struct Args {
     #[clap(long, short = 'w', action)]
     pub generate_web: bool,
 
-    /// Use wasm/wgpu backend
-    #[clap(long, short = 'a', action)]
-    pub wasm_mode: bool,
+    /// Use the pure JS legacy renderer
+    #[clap(long, short = 'l', action)]
+    pub legacy_renderer: bool,
 
     /// Serve the website at localhost:8000 after generating it
     #[clap(long, short)]

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
             page::actions::generate(&handlebars, &brawl_mods, &assets);
             page::action::generate(&handlebars, &brawl_mods, &assets);
             page::subactions::generate(&handlebars, &brawl_mods, &assets);
-            page::subaction::generate(&handlebars, &brawl_mods, &assets, args.wasm_mode);
+            page::subaction::generate(&handlebars, &brawl_mods, &assets, args.legacy_renderer);
             page::script::generate(&handlebars, &brawl_mods, &assets);
             page::scripts::generate(&handlebars, &brawl_mods, &assets);
             page::variables::generate(&handlebars, &brawl_mods, &assets);

--- a/website/src/page/subaction.rs
+++ b/website/src/page/subaction.rs
@@ -13,7 +13,7 @@ pub fn generate(
     handlebars: &Handlebars,
     brawl_mods: &BrawlMods,
     assets: &AssetPaths,
-    wasm_mode: bool,
+    legacy_renderer: bool,
 ) {
     for brawl_mod in &brawl_mods.mods {
         let mod_links = brawl_mods.gen_mod_links(brawl_mod.name.clone());
@@ -976,17 +976,17 @@ pub fn generate(
                     },
                 ];
 
-                let preload = if wasm_mode {
-                    &preload
-                } else {
+                let preload = if legacy_renderer {
                     &[] as &[Preload]
+                } else {
+                    &preload
                 };
 
-                let subaction_bincode = if wasm_mode {
+                let subaction_bincode = if legacy_renderer {
+                    String::new()
+                } else {
                     let bin = bincode::serialize(&subaction).unwrap();
                     general_purpose::STANDARD.encode(bin)
-                } else {
-                    String::new()
                 };
 
                 let page = SubactionPage {
@@ -1010,7 +1010,7 @@ pub fn generate(
                     frame_buttons,
                     twitter_image,
                     twitter_description,
-                    wasm_mode,
+                    legacy_renderer,
                 };
 
                 {
@@ -1087,7 +1087,7 @@ pub struct SubactionPage<'a> {
     frame_buttons: Vec<FrameButton>,
     twitter_description: String,
     twitter_image: String,
-    wasm_mode: bool,
+    legacy_renderer: bool,
 }
 
 #[derive(Serialize)]

--- a/website/templates/subaction.html.hbs
+++ b/website/templates/subaction.html.hbs
@@ -20,45 +20,7 @@
             <h1>{{title}}</h1>
             <div id="fighter-render">
             </div>
-            {{#if wasm_mode}}
-            <p>
-                |
-                {{#each frame_buttons}}
-                <a href="javascript:;" class="frame-button {{class}}" id="set_frame_{{index}}">{{index}}</a> |
-                {{/each}}
-            </p>
-            <div>
-                <button type="button" id="run-toggle" class="btn btn-sm btn-primary">Run</button>
-                <button type="button" id="previous-frame" class="btn btn-sm btn-primary">Previous
-                    Frame</button>
-                <button type="button" id="next-frame" class="btn btn-sm btn-primary">Next
-                    Frame</button>
-                <button type="button" id="face-left" class="btn btn-sm btn-primary">Face
-                    Left</button>
-                <button type="button" id="face-right" class="btn btn-sm btn-primary">Face
-                    Right</button>
-            </div>
-            <div class="form-check form-check-inline">
-                <select class="form-control" id="invulnerable-select" style="margin-right:10px;margin-top:4px;">
-                    <option>Hit</option>
-                    <option>Grab</option>
-                    <option>Trap Item</option>
-                </select>
-                <label class="form-check-label" for="invulnerable-select">Invulnerable</label>
-            </div>
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" id="wireframe-checkbox">
-                <label class="form-check-label" for="wireframe-checkbox">Wireframe</label>
-            </div>
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" id="ecb-checkbox">
-                <label class="form-check-label" for="ecb-checkbox">ECB</label>
-            </div>
-            <div class="form-check form-check-inline">
-                <input class="form-check-input" type="checkbox" id="perspective-checkbox">
-                <label class="form-check-label" for="perspective-checkbox">Perspective</label>
-            </div>
-            {{else}}
+            {{#if legacy_renderer}}
             <p>
                 |
                 {{#each frame_buttons}}
@@ -100,6 +62,44 @@
             <div class="form-check form-check-inline">
                 <input class="form-check-input" type="checkbox" id="perspective-checkbox"
                     onclick="fighter_render.perspective_toggle()">
+                <label class="form-check-label" for="perspective-checkbox">Perspective</label>
+            </div>
+            {{else}}
+            <p>
+                |
+                {{#each frame_buttons}}
+                <a href="javascript:;" class="frame-button {{class}}" id="set_frame_{{index}}">{{index}}</a> |
+                {{/each}}
+            </p>
+            <div>
+                <button type="button" id="run-toggle" class="btn btn-sm btn-primary">Run</button>
+                <button type="button" id="previous-frame" class="btn btn-sm btn-primary">Previous
+                    Frame</button>
+                <button type="button" id="next-frame" class="btn btn-sm btn-primary">Next
+                    Frame</button>
+                <button type="button" id="face-left" class="btn btn-sm btn-primary">Face
+                    Left</button>
+                <button type="button" id="face-right" class="btn btn-sm btn-primary">Face
+                    Right</button>
+            </div>
+            <div class="form-check form-check-inline">
+                <select class="form-control" id="invulnerable-select" style="margin-right:10px;margin-top:4px;">
+                    <option>Hit</option>
+                    <option>Grab</option>
+                    <option>Trap Item</option>
+                </select>
+                <label class="form-check-label" for="invulnerable-select">Invulnerable</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="wireframe-checkbox">
+                <label class="form-check-label" for="wireframe-checkbox">Wireframe</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="ecb-checkbox">
+                <label class="form-check-label" for="ecb-checkbox">ECB</label>
+            </div>
+            <div class="form-check form-check-inline">
+                <input class="form-check-input" type="checkbox" id="perspective-checkbox">
                 <label class="form-check-label" for="perspective-checkbox">Perspective</label>
             </div>
             {{/if}}
@@ -181,8 +181,7 @@
             <h3 id="script-other">Other</h3>
             {{{script_other}}}
 
-            {{#if wasm_mode }}
-            {{else}}
+            {{#if legacy_renderer }}
             <script>
                 const fighter_subaction_data = {{{ subaction }}};
                 const fighter_subaction_extent = {{{ subaction_extent }}};
@@ -451,7 +450,10 @@
     </div>
 </div>
 
-{{#if wasm_mode}}
+{{#if legacy_renderer}}
+<script src="https://unpkg.com/three@0.94.0/build/three.min.js"></script>
+<script src="{{assets.subaction_render_js}}"></script>
+{{else}}
 <script type="module">
     import init, { run } from "{{assets.fighter_renderer_js}}";
     const fighter_subaction_data = "{{{ subaction_bincode }}}";
@@ -461,9 +463,6 @@
         run(fighter_subaction_data);
     })();
 </script>
-{{else}}
-<script src="https://unpkg.com/three@0.94.0/build/three.min.js"></script>
-<script src="{{assets.subaction_render_js}}"></script>
 {{/if}}
 
 {{/inline}}


### PR DESCRIPTION
The legacy JS renderer is now disabled by default but enabled via the `--legacy-renderer` flag.